### PR TITLE
Small bug in Arin Template

### DIFF
--- a/Templates/Arin.php
+++ b/Templates/Arin.php
@@ -108,7 +108,7 @@ class Template_Arin extends AbstractTemplate
             }
         }
         
-        if (isset($Result->referral_server) && $ResultSet->referral_server != '') {
+        if (isset($Result->referral_server) && $Result->referral_server != '') {
             $Result->reset();
             $mapping = $Config->get($ResultSet->referral_server);
             $template = str_replace('whois://', '', $mapping['template']);


### PR DESCRIPTION
Line 111 of Templates/Arin.php checked for existence of $Result object and then tried to access $ResultSet object.  Updated this to use $Result in both cases.
