### PR TITLE
Update .pro whois-server

### DIFF
--- a/Config/whois.ini
+++ b/Config/whois.ini
@@ -429,7 +429,7 @@ pw[template] = afilias
 qa[server] = whois.registry.qa
 qa[template] = qa
 
-pro[server] = whois.registrypro.pro
+pro[server] = whois.afilias.net
 pro[template] = afilias
 
 re[server] = whois.nic.re


### PR DESCRIPTION
Current whois-server for .pro zone is dead. 

According to  http://www.iana.org/domains/root/db/pro.html - new server is whois.afilias.net.