### PR TITLE
Fix ErrorException: Undefined offset: 0

### DIFF
--- a/Templates/Afnic.php
+++ b/Templates/Afnic.php
@@ -126,7 +126,7 @@ class Afnic extends Regex
                 }
 
                 if ($contactType !== 'owner') {
-                    $contactObject->organization = $filteredAddress[0];
+                    $contactObject->organization = $filteredAddress[0] ?? null;
                     $contactObject->city = end($filteredAddress);
                     unset($filteredAddress[0]);
                 } else {


### PR DESCRIPTION
I kept receiving the following exception when retrieving domain information, in particular from .fr domains:

ErrorException: Undefined offset: 0 in /opt/src/vendor/novutec/whoisparser/Templates/Afnic.php:129 Stack trace: #0 /opt/src/vendor/novutec/whoisparser/Templates/Afnic.php(129)

As you can see below the address returns an empty array so bypasses the is_array check on line 121. I have therefore handled this on line 129 and is working fine for me now.

![image](https://cloud.githubusercontent.com/assets/17063751/26351589/2675eeec-3fb0-11e7-9fa8-030c49c01453.png)
