### PR TITLE
stop using null coalescing operator ( introduced in PHP 7 )

### DIFF
--- a/Templates/Afnic.php
+++ b/Templates/Afnic.php
@@ -127,7 +127,7 @@ class Afnic extends Regex
                 }
 
                 if ($contactType !== 'owner') {
-                    $contactObject->organization = $filteredAddress[0] ?? null;
+                    $contactObject->organization = isset($filteredAddress[0]) ? $filteredAddress[0] : null;
                     $contactObject->city = end($filteredAddress);
                     unset($filteredAddress[0]);
                 } else {


### PR DESCRIPTION
PR #11 introduced usage of null coalescing operator, which is a PHP 7 only feature
This PR reverts to pre-PHP 7 testing