### PR TITLE
Fix Arin's ReferralServer

### DIFF
--- a/Templates/Arin.php
+++ b/Templates/Arin.php
@@ -111,10 +111,10 @@ class Arin extends Regex
         }
         
         if (isset($Result->referral_server) && $Result->referral_server != '') {
+            $referralServer = str_replace('whois://', '', $Result->referral_server);
+            $mapping = $Config->get($referralServer);
             $Result->reset();
-            $mapping = $Config->get($Result->referral_server);
-            $template = str_replace('whois://', '', $mapping['template']);
-            $Config->setCurrent($Config->get($template));
+            $Config->setCurrent($Config->get($mapping['template']));
             $WhoisParser->call();
         }
     }


### PR DESCRIPTION
Arin's ReferralServer was broken probably since 2014 because of [this](https://github.com/3name/WhoisParser/commit/1383d412d7b018b4aa0bead4b8c2b3f74f27c683) commit. The issue is that `$Result` was `reset`'ted first, and then it tried to get `$Result->referral_server`, which was `null` at this moment.